### PR TITLE
Update build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,3 @@
-#! /usr/bin/env bash
-
 mkdir _build && cd _build
 NETCDF_DIR=$PREFIX cmake \
     -DCMAKE_BUILD_TYPE=Release \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,5 @@
 #! /usr/bin/env bash
 
-if [[ `uname -s` == 'Darwin' ]]; then
-    export MACOSX_DEPLOYMENT_TARGET=""
-fi
-
 mkdir _build && cd _build
 NETCDF_DIR=$PREFIX cmake \
     -DCMAKE_BUILD_TYPE=Release \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,12 +31,8 @@ requirements:
     - coretran
 
 test:
-  source_files:
-    - pipestem
   commands:
-    - cd pipestem
-    - prms control.default
-    - test -f output/summary_daily.nc
+    - prms
 
 about:
   home: https://www.usgs.gov/software/precipitation-runoff-modeling-system-prms

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "prms" %}
 {% set version = "6.0.0" %}
 {% set release = "alpha" %}
-{% set build_number = "3" %}
+{% set build_number = "4" %}
 
 package:
   name: {{ name }}
@@ -9,10 +9,10 @@ package:
 
 source:
   git_url: https://github.com/rmcd-mscb/{{ name }}
-  git_rev: 707f8489f585809c03ccd540e6d1c6b3cadb99dd
+  git_rev: 61567b74c5bb7e4cca18ce19301d41dc4de53d53
 
 build:
-  string: {{ release }}{{ build_number }}
+  string: {{ release }}.{{ build_number }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   build:
     - cmake
     - make
-    - libgfortran >=4.0.0 # [osx]
     - {{ compiler('fortran') }}
     - libnetcdf
     - netcdf-fortran


### PR DESCRIPTION
This PR updates the PRMS recipe to use use the current tip of the 6.0.0_dev_bmi branch on the rmcd-mscb fork. It includes:

* Variables made public that will allow the bmi-prms6-surface component tests to pass
* A simplified test, since the pipestem example has been removed
* Removed cruft once needed to build on macOS
* The correct semver version: 6.0.0-alpha.4